### PR TITLE
WS-BO Fix Array to string conversion in OrderCarrier

### DIFF
--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -104,7 +104,7 @@ class OrderCarrierCore extends ObjectModel
 
         $metadata = '';
         foreach ($products as $product) {
-            $prod_obj = new Product((int)$product['product_id']);
+            $prod_obj = new Product((int)$product['product_id'], false, $order->id_lang);
 
             //try to get the first image for the purchased combination
             $img = $prod_obj->getCombinationImages($order->id_lang);


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       |  "develop" 
| Description?  | add idlang loading product because Link expect a string not a array
| Type?         | bug fix 
| Category?     | BO - WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no ticket
| How to test?  | Php notice creating new OrderCarrier Object using Webservice
